### PR TITLE
rendered list of users with admin verification

### DIFF
--- a/Tabloid/Controllers/UserProfileController.cs
+++ b/Tabloid/Controllers/UserProfileController.cs
@@ -23,6 +23,12 @@ namespace Tabloid.Controllers
             return Ok(_userProfileRepository.GetByFirebaseUserId(firebaseUserId));
         }
 
+        [HttpGet]
+        public IActionResult Get()
+        {
+            return Ok(_userProfileRepository.GetAll());
+        }
+
         [HttpPost]
         public IActionResult Post(UserProfile userProfile)
         {

--- a/Tabloid/Repositories/UserProfileRepository.cs
+++ b/Tabloid/Repositories/UserProfileRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Tabloid.Data;
 using Tabloid.Models;
@@ -20,6 +21,15 @@ namespace Tabloid.Repositories
                        .Include(up => up.UserType) 
                        .FirstOrDefault(up => up.FirebaseUserId == firebaseUserId);
         }
+
+        public List<UserProfile> GetAll()
+        {
+            return _context.UserProfile
+                .Include(up => up.UserType)
+                .OrderBy(up => up.DisplayName)
+                .ToList();
+        }
+
 
         public void Add(UserProfile userProfile)
         {

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -11,9 +11,12 @@ import Hello from "./Hello";
 import { CategoryList } from "./categories/CategoryList";
 import PostDetails from "./posts/PostDetails";
 import AddPostForm from "./posts/AddPostForm";
+import { UserProfileList } from "./userProfiles/UserProfileList";
+
 
 export default function ApplicationViews() {
-  const { isLoggedIn } = useContext(UserProfileContext);
+  const { isLoggedIn, isAdmin } = useContext(UserProfileContext);
+  const userProfile = JSON.parse(sessionStorage.getItem("userProfile"));
 
   return (
     <main>
@@ -55,6 +58,10 @@ export default function ApplicationViews() {
 
         <Route path="/categories">
           {isLoggedIn ? <CategoryList /> : <Redirect to="/login" />}
+        </Route>
+
+        <Route path="/userProfiles" exact>
+          {isLoggedIn && isAdmin ? <UserProfileList /> : <Redirect to="/welcome" />}
         </Route>
         
       </Switch>

--- a/Tabloid/client/src/components/Header.js
+++ b/Tabloid/client/src/components/Header.js
@@ -15,6 +15,7 @@ export default function Header() {
   const { isLoggedIn, logout, isAdmin } = useContext(UserProfileContext);
   const [isOpen, setIsOpen] = useState(false);
   const toggle = () => setIsOpen(!isOpen);
+ 
 
   return (
     <div>
@@ -40,7 +41,7 @@ export default function Header() {
               </NavItem>
               <NavItem>
                 <NavLink tag={RRNavLink} to ="/tags">Tags</NavLink>
-              </NavItem>
+              </NavItem> 
               {isAdmin &&
                 <NavItem>
                   <NavLink tag={RRNavLink} to ="/userProfiles">Users</NavLink>

--- a/Tabloid/client/src/components/Header.js
+++ b/Tabloid/client/src/components/Header.js
@@ -12,7 +12,7 @@ import {
 import { UserProfileContext } from "../providers/UserProfileProvider";
 
 export default function Header() {
-  const { isLoggedIn, logout } = useContext(UserProfileContext);
+  const { isLoggedIn, logout, isAdmin } = useContext(UserProfileContext);
   const [isOpen, setIsOpen] = useState(false);
   const toggle = () => setIsOpen(!isOpen);
 
@@ -41,7 +41,13 @@ export default function Header() {
               <NavItem>
                 <NavLink tag={RRNavLink} to ="/tags">Tags</NavLink>
               </NavItem>
+              {isAdmin &&
+                <NavItem>
+                  <NavLink tag={RRNavLink} to ="/userProfiles">Users</NavLink>
+                </NavItem> 
+              }
               </>
+              
             }
             {!isLoggedIn &&
               <>

--- a/Tabloid/client/src/components/categories/CategoryForm.js
+++ b/Tabloid/client/src/components/categories/CategoryForm.js
@@ -27,7 +27,7 @@ export const CategoryForm = () => {
                 />
             </fieldset>
 
-            <div className="btn--addCategory">
+            <div>
                 <Button 
                     type="submit" 
                     color="info" 

--- a/Tabloid/client/src/components/posts/AddPostForm.js
+++ b/Tabloid/client/src/components/posts/AddPostForm.js
@@ -29,7 +29,6 @@ const AddPostForm = () => {
             isApproved: true,
             categoryId: catId.current.value
         }
-        debugger
         addPost(newPostObj).then(() => {
             history.push("/posts")
         })

--- a/Tabloid/client/src/components/userProfiles/UserProfile.css
+++ b/Tabloid/client/src/components/userProfiles/UserProfile.css
@@ -1,0 +1,28 @@
+.userProfileList {
+    margin: 100px auto;
+    width: 80%;
+}
+
+.userProfile  {
+    display: flex;
+    flex: 2;
+    justify-content: space-between;
+}
+
+.header--userList {
+    display: flex;
+    justify-content: space-around;
+}
+
+.user--info {
+    width: 25%;
+    margin-left: 0px;
+}
+
+.input--addCategory {
+    width: 80%;
+}
+
+.icon--userProfile {
+    padding-right: 25px;
+}

--- a/Tabloid/client/src/components/userProfiles/UserProfile.js
+++ b/Tabloid/client/src/components/userProfiles/UserProfile.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { ListGroupItem, ListGroup } from 'reactstrap';
+import "./UserProfile.css"
+
+export const UserProfile = ({ userProfile }) => {
+
+    return (
+        <ListGroupItem>
+            <ListGroup horizontal className="userProfile">
+                <div className="user--info">
+                    {userProfile.fullName}
+                </div> 
+                <div className="user--info">
+                    {userProfile.displayName}
+                </div> 
+                <div className="user--info">
+                    {userProfile.userType.name}
+                </div> 
+                <ListGroup horizontal>
+                    <div className="icon--userProfile"> 
+                        <i className="fa fa-info-circle" aria-hidden="true"></i>
+                    </div>
+                    <div className="icon--userProfile"> 
+                        <i className="fa fa-window-close-o" aria-hidden="true"></i>
+                    </div>
+                </ListGroup>
+            </ListGroup>
+        </ListGroupItem>       
+    )
+}

--- a/Tabloid/client/src/components/userProfiles/UserProfileList.js
+++ b/Tabloid/client/src/components/userProfiles/UserProfileList.js
@@ -1,0 +1,32 @@
+import React, { useContext, useEffect } from 'react';
+import { ListGroup } from 'reactstrap';
+import { UserProfile } from "../userProfiles/UserProfile";
+import { UserProfileContext } from "../../providers/UserProfileProvider";
+import "./UserProfile.css";
+
+export const UserProfileList = () => {
+    const { userProfiles, getUserProfiles } = useContext(UserProfileContext)
+
+    useEffect(() => {
+        getUserProfiles();
+        // eslint-disable-next-line 
+      }, []);
+
+    return (
+        <>
+            <section className="userProfileList">
+                <ListGroup horizontal className="header--userList">
+                    <h5 className="user-info">Full Name</h5>
+                    <h5 className="user-info">Display Name</h5>
+                    <h5 className="user-info">User Type</h5>
+                    <h5 className="user-info">Actions</h5>
+                </ListGroup>
+                <ListGroup>
+                    {userProfiles.map(up =>
+                        <UserProfile key={up.id} userProfile={up}/>
+                    )} 
+                </ListGroup>
+            </section>
+        </>
+    )
+}

--- a/Tabloid/client/src/providers/UserProfileProvider.js
+++ b/Tabloid/client/src/providers/UserProfileProvider.js
@@ -7,9 +7,17 @@ export const UserProfileContext = createContext();
 
 export function UserProfileProvider(props) {
   const apiUrl = "/api/userprofile";
-
-  const userProfile = sessionStorage.getItem("userProfile");
+  const userProfile = JSON.parse(sessionStorage.getItem("userProfile"));
   const [isLoggedIn, setIsLoggedIn] = useState(userProfile != null);
+  const [isAdmin, setAdmin] = useState(false)
+  
+  useEffect(() => {
+    if (isLoggedIn && userProfile.userTypeId === 1) {
+      setAdmin(true)
+    }
+  })
+ 
+  const [userProfiles, setUserProfiles] = useState([])
 
   const [isFirebaseReady, setIsFirebaseReady] = useState(false);
   useEffect(() => {
@@ -56,6 +64,18 @@ export function UserProfileProvider(props) {
       }).then(resp => resp.json()));
   };
 
+  const getUserProfiles = () => {
+    getToken().then((token) =>
+    fetch(apiUrl, {
+        method: "GET",
+        headers: {
+        Authorization: `Bearer ${token}`
+        }
+    })
+    .then(resp => resp.json())
+    .then(setUserProfiles))
+}
+
   const saveUser = (userProfile) => {
     return getToken().then((token) =>
       fetch(apiUrl, {
@@ -69,7 +89,7 @@ export function UserProfileProvider(props) {
   };
 
   return (
-    <UserProfileContext.Provider value={{ isLoggedIn, login, logout, register, getToken }}>
+    <UserProfileContext.Provider value={{ isAdmin, isLoggedIn, login, logout, register, getToken, getUserProfiles, userProfiles }}>
       {isFirebaseReady
         ? props.children
         : <Spinner className="app-spinner dark"/>}

--- a/Tabloid/client/src/providers/UserProfileProvider.js
+++ b/Tabloid/client/src/providers/UserProfileProvider.js
@@ -14,8 +14,8 @@ export function UserProfileProvider(props) {
   useEffect(() => {
     if (isLoggedIn && userProfile.userTypeId === 1) {
       setAdmin(true)
-    }
-  })
+    }})
+  
  
   const [userProfiles, setUserProfiles] = useState([])
 
@@ -40,6 +40,7 @@ export function UserProfileProvider(props) {
       .then(() => {
         sessionStorage.clear()
         setIsLoggedIn(false);
+        setAdmin(false);
       });
   };
 


### PR DESCRIPTION
### Server-Side Changes
- Added GetAll() to UserProfileRepository and ordered by DisplayName
- Added [HttpGet] to UserProfileController

### Client-Side Changes
- Added GetUserProfiles() to UserProfileProvider
- Used State and Effect hooks to export "isAdmin" verification from UserProfileProvider
- Added "isAdmin" verification to "Users" nav link in Header.js
- Added route to /userProfiles and "isAdmin" verification to render list of users
- Created UserProfile to display FullName, DisplayName, and UserType for each user
- Added icons for details and deactivation (not functional yet)

### Testing
- Make sure FirebaseProjectId in appsettings.Local.json is yours
- Execute Tabloid.sln in VS and `npm start' from Client
- Login as an admin, click on "Users" and make sure list of users appears, ordered by DisplayName
- Login as non-admin and make sure "Users" link is not in navbar, and that you can't access page by going to "/userProfiles"

### Additional Notes
TEAM GIRLS WINS!

